### PR TITLE
Fix test for download image by provided path

### DIFF
--- a/tests/test_youversion.py
+++ b/tests/test_youversion.py
@@ -90,6 +90,9 @@ class ImageTest(unittest.TestCase):
             actual_save_path = votd.image.download(width=1, height=1, save_path=save_path)
             if not actual_save_path or actual_save_path == '' or not os.path.exists(actual_save_path):
                 raise AssertionError()
+
+            if not actual_save_path == save_path:
+                raise AssertionError()
         finally:
             if actual_save_path:
                 os.remove(actual_save_path)


### PR DESCRIPTION
Fixes #5 by checking that the downloaded file path matches the provided save path.