### PR TITLE
Prepare release of v0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup
 
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 
 def read(file_name):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 
 def read(file_name):

--- a/youversion/youversion.py
+++ b/youversion/youversion.py
@@ -421,9 +421,6 @@ class API:
             list of VerseOfTheDay objects
         """
         json = self._get('verse_of_the_day', params={'version_id': self.bible_version.id})
-        if not json or 'data' not in json:
-            return False, 0, None
-
         votds = [VerseOfTheDay(bible_version=self.bible_version, json=data) for data in json.get('data', [])]
         next_page = json.get('next_page', False)
         page_size = json.get('page_size', len(votds))


### PR DESCRIPTION
This merge preps for the release of v0.1.2 which fixes/adds URL support on Windows hosts.

This merge also removes some redundant JSON response checking that resulted in a drop in test coverage.